### PR TITLE
Remove home link.

### DIFF
--- a/resources/js/pages/Blocks/BlockCreate.tsx
+++ b/resources/js/pages/Blocks/BlockCreate.tsx
@@ -37,7 +37,6 @@ const BlockCreate = () => {
     <>
       <PageHeader
         title="Create block"
-        storeHash={store_hash}
         backLinkText="Blocks"
         backLinkHref={backLinkHref}
       />

--- a/resources/js/pages/Blocks/BlockEdit.tsx
+++ b/resources/js/pages/Blocks/BlockEdit.tsx
@@ -11,7 +11,7 @@ const BlockEdit = () => {
   const {store_hash, block_id} = useParams();
   const location = useLocation();
   const backLinkHref = location?.state?.backLinkHref ?? `/stores/${store_hash}`;
-  
+
   const [initialBlock, blockError, blockIsLoading] = useBlock(store_hash, block_id);
   const [snippet, snippetError, snippetIsLoading] = useSnippet(store_hash, block_id);
   const [designs, designError, isDesignsLoading] = useDesigns(store_hash);
@@ -35,8 +35,7 @@ const BlockEdit = () => {
   return (
     <>
       <PageHeader
-        title={block?.name ?? 'Update block'}
-        storeHash={store_hash}
+        title={block?.name ? `Edit ${block.name}` : 'Edit design'}
         backLinkText="Blocks"
         backLinkHref={backLinkHref}
       />

--- a/resources/js/pages/Dashboard.tsx
+++ b/resources/js/pages/Dashboard.tsx
@@ -155,7 +155,7 @@ const Dashboard = () => {
 
   return (
     <>
-      <PageHeader title="Commerce Block Party" storeHash={store_hash}/>
+      <PageHeader title="Commerce Block Party"/>
       <PageBody>
         <ContentLoading
           loading={isBlocksLoading || isDesignsLoading}

--- a/resources/js/pages/Designs/DesignCreate.tsx
+++ b/resources/js/pages/Designs/DesignCreate.tsx
@@ -25,12 +25,11 @@ const DesignCreate = () => {
     onSuccess,
     onError
   );
-  
+
   return (
     <>
       <PageHeader
         title="Create design"
-        storeHash={store_hash}
         backLinkText="Designs"
         backLinkHref={backLinkHref}
       />

--- a/resources/js/pages/Designs/DesignEdit.tsx
+++ b/resources/js/pages/Designs/DesignEdit.tsx
@@ -37,7 +37,6 @@ const DesignEdit = () => {
     <>
       <PageHeader
         title={design?.name ? `Edit ${design.name}` : 'Edit design'}
-        storeHash={store_hash}
         backLinkText="Designs"
         backLinkHref={backLinkHref}
       />


### PR DESCRIPTION
Our app doesn't go that deep so we can get away with this to make it cleaner.

Also made the edit block page title match the format of the edit design page title.