### PR TITLE
Fix so that search box retains focus on each keystroke.

### DIFF
--- a/resources/js/hooks/useBlocks.ts
+++ b/resources/js/hooks/useBlocks.ts
@@ -1,6 +1,7 @@
 import {useSWRFetch} from './useSWRFetch';
+import {laggy} from '../utils';
 
 export const useBlocks = (store_hash: string, queryParams: object = {}) => {
-  const [data, error, isPending, mutate] = useSWRFetch(`/api/stores/${store_hash}/blocks`, queryParams, store_hash);
+  const [data, error, isPending, mutate] = useSWRFetch(`/api/stores/${store_hash}/blocks`, queryParams, store_hash, {use: [laggy]});
   return [data, error, isPending, mutate];
 };


### PR DESCRIPTION
Each key stroke would trigger a new API request for blocks. While this was loading, the loading spinner would be shown. Then when the response was received, the blocks list would update but the search box would no longer have focus.

This change avoids the loading spinner being shown for a microsecond and so the search box does not lose focus.

![Screenshot 2022-11-14 at 16 48 56](https://user-images.githubusercontent.com/553566/201717891-df353ff6-7f1a-4f09-a123-3744e2ebf243.png)

