### PR TITLE
Fix helpscout start chat.

### DIFF
--- a/resources/js/components/HelpPanel.tsx
+++ b/resources/js/components/HelpPanel.tsx
@@ -4,7 +4,7 @@ import {useHelpScoutBeacon} from '../hooks';
 import ConfigContext from '../context/ConfigContext';
 
 const HelpPanel = () => {
-  const [, startChat] = useHelpScoutBeacon();
+  const [startChat] = useHelpScoutBeacon();
   const context = useContext(ConfigContext);
 
   return (


### PR DESCRIPTION
Chat didn't start as hook no longer returns an array of length two, but one.