### PR TITLE
Fix/channels

### DIFF
--- a/app/Http/Resources/ConfigurationResource.php
+++ b/app/Http/Resources/ConfigurationResource.php
@@ -20,7 +20,7 @@ class ConfigurationResource extends JsonResource
         // so that the addToCart URL in the response reflects the channel specific store.
         // However, there's a graphql bug with filters right now, so when it's fixed it will work.
         return [
-            'store_url' => $this->store->domain,
+            'store_url' => sprintf('store-%s.mybigcommerce.com', $this->store->store_hash),
             'block_name' => Str::slug($this->name),
             'block_type' => $this->block_type,
             'access_token' => $this->graphql_access_token,

--- a/app/Jobs/CreateToken.php
+++ b/app/Jobs/CreateToken.php
@@ -10,6 +10,8 @@ use Illuminate\Support\Facades\Log;
 
 class CreateToken extends BigcommerceJob
 {
+    const MAIN_CHANNEL = 1;
+
     /**
      * Create a new job instance.
      *
@@ -31,9 +33,10 @@ class CreateToken extends BigcommerceJob
     public function handle(Bigcommerce $bc)
     {
         $expiryDate = now()->addDays(30);
+        // while the channel specific graphql route doesn't work, we need to use channel 1 for any tokens
         $payload = new StorefrontApiTokenPayload(
             $this->block->valid_domain,
-            $this->block->channel_id,
+            self::MAIN_CHANNEL,
             $expiryDate->unix()
         );
         /** @var BigcommerceStore $store */
@@ -50,5 +53,10 @@ class CreateToken extends BigcommerceJob
                 'graphql_access_token_domain' => $domain,
             ]);
         });
+
+        Log::info('PUBLISH TOKEN', [
+            'store_hash' => $this->block->store->store_hash,
+            'domain' => $this->block->valid_domain
+        ]);
     }
 }

--- a/frontend/resources/js/helpers/pageBuilder.ts
+++ b/frontend/resources/js/helpers/pageBuilder.ts
@@ -1,1 +1,7 @@
-export const isPageBuilder = () => window.parent.location.href.includes('page-builder');
+export const isPageBuilder = () => {
+  try {
+    return window.parent.location.href.includes('page-builder');
+  } catch (e) {
+    return true;
+  }
+};


### PR DESCRIPTION
This PR fixes 2 issues:

1. Where there's a CORS issue on the URL/channel-specific graphQL request. As we cannot use the channel-specific domain, the token must be channel 1 for the main store domain. This can be reverted after they've fixed the issue with filters.
2. Pagebuilder errors on channel specific domains due to the browser blocking access to a different domains window.parent.